### PR TITLE
ci: migrate to self-hosted stlc release pipeline (de-Stainless)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
-
 jobs:
   build:
     timeout-minutes: 10
@@ -21,62 +20,37 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ${{ github.repository == 'stainless-sdks/dodo-payments-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     if: |-
-      github.repository == 'stainless-sdks/dodo-payments-go' &&
+      github.repository == 'dodopayments/dodopayments-go' &&
       (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Get GitHub OIDC Token
-        if: |-
-          github.repository == 'stainless-sdks/dodo-payments-go' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
-        id: github-oidc
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: core.setOutput('github_token', await core.getIDToken());
-
-      - name: Upload tarball
-        if: |-
-          github.repository == 'stainless-sdks/dodo-payments-go' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
-        env:
-          URL: https://pkg.stainless.com/s
-          AUTH: ${{ steps.github-oidc.outputs.github_token }}
-          SHA: ${{ github.sha }}
-        run: ./scripts/utils/upload-artifact.sh
   lint:
     timeout-minutes: 10
     name: lint
-    runs-on: ${{ github.repository == 'stainless-sdks/dodo-payments-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Setup go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
-
       - name: Run lints
         run: ./scripts/lint
   test:
     timeout-minutes: 10
     name: test
-    runs-on: ${{ github.repository == 'stainless-sdks/dodo-payments-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Setup go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
-
       - name: Bootstrap
         run: ./scripts/bootstrap
-
       - name: Run tests
         run: ./scripts/test

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -1,0 +1,19 @@
+name: Release Doctor
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  release_doctor:
+    name: release doctor
+    runs-on: ubuntu-latest
+    if: github.repository == 'dodopayments/dodopayments-go' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please') || github.head_ref == 'next')
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check release environment
+        run: |
+          bash ./bin/check-release-environment

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,36 @@
+name: Release Please
+
+# Repo-local release pipeline (replaces the Stainless GitHub App).
+# Opens/maintains a release PR from Conventional Commits on main; on merge it
+# tags + creates a GitHub Release, which triggers this repo's publish-*.yml.
+# Auth: the dodo-squirrels App token (NOT GITHUB_TOKEN) so that the created
+# release fires the `release: [published]` event that publish-*.yml listens on.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint dodo-squirrels App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          # dodo-squirrels App (app_id 3728163). Set repo/org var
+          # APP_CLIENT_ID = Iv23lizGR7cMOzRpoJHc. `client-id` replaces the
+          # deprecated `app-id` input.
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Run release-please
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Go modules publish via git tags resolved by the module proxy; there is no
+# package-registry secret to validate. release-please creates the tag +
+# GitHub Release, after which `go get` / proxy.golang.org resolve the new
+# version automatically. This check is a structural no-op kept for parity
+# with the other SDK repos' release-doctor flow.
+
+echo "The environment is ready to push releases (Go: tag-based, no publish secret required)!"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "versioning": "prerelease",


### PR DESCRIPTION
Migrate CI/release off the shutting-down Stainless SaaS to the self-hosted stlc pipeline.

- Remove dead `pkg.stainless.com` upload steps + Depot `runs-on` ternaries (collapse to GitHub-hosted runners).
- Repoint `release-please-config.json` `$schema` to googleapis.
- Add `release-please.yml` (replaces Stainless-run release-please; opens/maintains the release PR and creates the GitHub Release that triggers this repo's publish workflow). Auth via the dodo-squirrels GitHub App.
- (go/csharp) also add `release-doctor.yml` + `bin/check-release-environment`.

Requires repo/org vars+secrets `APP_CLIENT_ID=Iv23lizGR7cMOzRpoJHc` + `APP_PRIVATE_KEY` to be set; the new workflows no-op until then.